### PR TITLE
Chapter 7: MiddleWare

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -6,6 +6,11 @@ use Illuminate\Http\Request;
 
 class UserController extends Controller
 {
+    public function __construct()
+    {
+        $this->middleware('check.admin');
+    }
+
     /**
      * Display a listing of the resource.
      *

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -3,6 +3,7 @@
 namespace App\Http;
 
 use Illuminate\Foundation\Http\Kernel as HttpKernel;
+use App\Http\Middleware\CheckAdmin;
 
 class Kernel extends HttpKernel
 {
@@ -63,5 +64,6 @@ class Kernel extends HttpKernel
         'signed' => \Illuminate\Routing\Middleware\ValidateSignature::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
+        'check.admin' => \App\Http\Middleware\CheckAdmin::class,
     ];
 }

--- a/app/Http/Middleware/CheckAdmin.php
+++ b/app/Http/Middleware/CheckAdmin.php
@@ -16,7 +16,7 @@ class CheckAdmin
      */
     public function handle(Request $request, Closure $next)
     {
-        if(!$request->isAdmin) {
+        if (!$request->isAdmin) {
             return redirect('home');
         }
 

--- a/app/Http/Middleware/CheckAdmin.php
+++ b/app/Http/Middleware/CheckAdmin.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+
+class CheckAdmin
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure(\Illuminate\Http\Request): (\Illuminate\Http\Response|\Illuminate\Http\RedirectResponse)  $next
+     * @return \Illuminate\Http\Response|\Illuminate\Http\RedirectResponse
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        if(!$request->isAdmin) {
+            return redirect('home');
+        }
+
+        return $next($request);
+    }
+}


### PR DESCRIPTION
1. Middleware dùng để làm gì:
- MiddleWare dùng để lọc các request HTTP đến ứng dụng
2. Phân biệt Global Middleware, Group MiddleWare và Route MiddleWare
- Glodbal MiddleWare: nó sẽ được autoload khi có một HTTP request gửi đến, không cần phải khai báo ở route. Khi đăng kí cần khai báo ở $middleware của class app/Http/Kernel.php.
- Route MiddleWare: chỉ được gọi khi request đi vào route tương ứng và thực thi ở controller tương ứng với route. Khi đăng ký cần khai báo ở $routeMiddleware của class app/Http/Kernel.php với key và tên class middleWare
- Group MiddleWare:  được gán vào routes và controller sử dụng cú pháp tương tự như với Route MiddleWare nhưng khác nhau là được gán khi muốn gom các middleware một nhóm dưới dạng key chung để dễ dàng đăng ký cho route. Khi đăng kí cần khai báo ở $middlewareGroups của class app/Http/Kernel.php.

